### PR TITLE
Support headers in JSON production

### DIFF
--- a/json.c
+++ b/json.c
@@ -465,6 +465,18 @@ static int parse_string(void *ctx_, const unsigned char *stringVal,
             ctx->payload = stringVal;
             ctx->payload_len = stringLen;
             break;
+        case headers:
+        	if (!ctx->headers) {
+        		ctx->headers = rd_kafka_headers_new(8);
+        	}
+        	if (ctx->last_header_name) {
+        		rd_kafka_header_add(ctx->headers, (const char *)ctx->last_header_name, ctx->last_header_name_len, stringVal, stringLen);
+        		ctx->last_header_name = 0;
+        	} else {
+        		ctx->last_header_name = stringVal;
+        		ctx->last_header_name_len = stringLen;
+        	}
+        	break;
         case noval:
             KC_ERROR("Has not read key");
             break;
@@ -486,6 +498,7 @@ static int parse_map_key(void *ctx_, const unsigned char *stringVal, size_t stri
     check_key(broker)
     check_key(key)
     check_key(payload)
+    check_key(headers)
 #undef check_key
     KC_ERROR("Does not matching anything for key: %s", stringVal);
     return 1;

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -197,7 +197,7 @@ void fmt_term (void);
 #if ENABLE_JSON
 
 typedef enum {
-    noval, topic, partition, offset, tstype, ts, broker, key, payload
+    noval, topic, partition, offset, tstype, ts, broker, key, payload, headers
 } lastKey;
 
 typedef struct
@@ -217,6 +217,9 @@ typedef struct
     int finished;
     int processed;
     lastKey lastkey;
+    rd_kafka_headers_t *headers;
+    const unsigned char *last_header_name;
+    size_t last_header_name_len;
 } kafkacatMessageContext;
 
 /*


### PR DESCRIPTION
@qiujiangkun 

Adds support for producing per-message headers in -P -J mode.  See comment [here](https://github.com/edenhill/kafkacat/pull/295#issuecomment-789185286) for more details.