### PR TITLE
Fix for "error: too few arguments to function 'produce'"

### DIFF
--- a/kcat.c
+++ b/kcat.c
@@ -496,7 +496,7 @@ static void producer_run (FILE *fp, char **paths, int pathcnt) {
                 }
 
                 /* Produce message */
-                produce((char *)buf, len, key, key_len, msgflags, buffer);
+                produce((char *)buf, len, key, key_len, msgflags, NULL, buffer);
                 if (msg.headers) {
 					rd_kafka_headers_destroy(msg.headers);
 					msg.headers = 0;


### PR DESCRIPTION
- Executing `./bootstrap.sh --no-install-deps --no-enable-static` off this branch causes
```bash
44.27 kcat.c: In function 'producer_run':
44.27 kcat.c:499:17: error: too few arguments to function 'produce'
44.27   499 |                 produce((char *)buf, len, key, key_len, msgflags, buffer);
44.27       |                 ^~~~~~~
44.27 kcat.c:196:13: note: declared here
44.27   196 | static void produce (void *buf, size_t len,
44.27       |             ^~~~~~~
44.30 make: *** [mklove/Makefile.base:97: kcat.o] Error 1
```
- The changes in this PR lets it past the breaking point.
- However, I am not sure if `NULL` is a valid argument from this point.